### PR TITLE
feat: create files for limiter, configuration and constants

### DIFF
--- a/app.js
+++ b/app.js
@@ -3,7 +3,6 @@
 const express = require('express');
 const mongoose = require('mongoose');
 const helmet = require('helmet');
-const rateLimit = require('express-rate-limit');
 const cors = require('cors');
 require('dotenv').config();
 const { errors } = require('celebrate');
@@ -11,6 +10,8 @@ const usersRouter = require('./routes/users');
 const articlesRouter = require('./routes/articles');
 const { login, createUser } = require('./controllers/users');
 const { requestLogger, errorLogger } = require('./middlewares/logger');
+const { MONGO_SERVER } = require('./utils/configuration');
+const limiter = require('./middlewares/limiter');
 const auth = require('./middlewares/auth');
 const NotFoundError = require('./errors/NotFoundError');
 const ConflictError = require('./errors/ConflictError');
@@ -21,12 +22,8 @@ app.use(cors());
 app.options('*', cors());
 
 const { PORT = 3000 } = process.env;
-const limiter = rateLimit({
-  windowMs: 1 * 60 * 1000,
-  max: 500,
-});
 
-mongoose.connect('mongodb://localhost:27017/news-explorer');
+mongoose.connect(MONGO_SERVER);
 
 app.use(helmet());
 app.use(express.json());

--- a/controllers/users.js
+++ b/controllers/users.js
@@ -1,6 +1,7 @@
 const jwt = require('jsonwebtoken');
 const bcrypt = require('bcryptjs');
 const User = require('../models/user');
+const { privateKey } = require('../utils/configuration');
 const NotFoundError = require('../errors/NotFoundError');
 const AuthorizationError = require('../errors/AuthorizationError');
 
@@ -36,7 +37,7 @@ module.exports.login = (req, res, next) => {
       }
       const token = jwt.sign(
         { _id: user._id },
-        NODE_ENV === 'production' ? JWT_SECRET : 'some-secret-key',
+        NODE_ENV === 'production' ? JWT_SECRET : privateKey,
         { expiresIn: '7d' }
       );
       res.send({ token });

--- a/middlewares/auth.js
+++ b/middlewares/auth.js
@@ -1,4 +1,5 @@
 const jwt = require('jsonwebtoken');
+const { privateKey } = require('../utils/configuration');
 const AuthorizationError = require('../errors/AuthorizationError');
 
 const { NODE_ENV, JWT_SECRET } = process.env;
@@ -15,7 +16,7 @@ const auth = (req, res, next) => {
   let payload;
 
   try {
-    payload = jwt.verify(token, NODE_ENV === 'production' ? JWT_SECRET : 'some-secret-key');
+    payload = jwt.verify(token, NODE_ENV === 'production' ? JWT_SECRET : privateKey);
   } catch (err) {
     throw new AuthorizationError('Authorization required');
   }

--- a/middlewares/limiter.js
+++ b/middlewares/limiter.js
@@ -1,0 +1,6 @@
+const rateLimit = require('express-rate-limit');
+
+module.exports.limiter = rateLimit({
+  windowMs: 1 * 60 * 1000,
+  max: 500,
+});

--- a/utils/configuration.js
+++ b/utils/configuration.js
@@ -1,0 +1,6 @@
+const { NODE_ENV, DATABASE_URL } = process.env;
+
+module.exports.MONGO_SERVER =
+  NODE_ENV === 'production' ? DATABASE_URL : 'mongodb://localhost:27017/news-explorer';
+
+module.exports.privateKey = 'some-secret-key';

--- a/utils/constants.js
+++ b/utils/constants.js
@@ -1,0 +1,13 @@
+const notFoundArticle = 'Article could not be found!';
+const notFoundUser = 'User could not be found!';
+const forbidden = 'That is not yours to touch!';
+const notAuthorized = 'Authorization required';
+const incorrectEmailPassword = 'Incorrect email or password';
+
+module.exports = {
+  notFoundArticle,
+  notFoundUser,
+  forbidden,
+  notAuthorized,
+  incorrectEmailPassword,
+};


### PR DESCRIPTION
Hi uwu! The API is now accessible via the provided domain and I also completed the following points from the review:

- [ ] Configuration and constants are stored in separate files:
    - [ ] The Mongo server address and the private key for the JWT in development mode are stored inside a separate configuration file.
    - [ ] Application constants (response and error messages) are stored inside a separate file with constants.

- [ ] The rate limiter is configured in a separate file and imported into app.js.
- [ ]  In production mode, the database address is taken from process.env.

So the error messages are now stored in a separate file, but I haven't imported them in the corresponding files yet (I'd like to discuss this with you first).