### PR TITLE
fix: change keywords for article route, controller, model

### DIFF
--- a/controllers/articles.js
+++ b/controllers/articles.js
@@ -7,14 +7,14 @@ const { forbidden, articleNotFound } = require('../utils/constants');
 
 module.exports.getArticles = (req, res, next) => {
   Article.find({})
-    .then((articles) => res.status(200).send({ articles }))
+    .then((articles) => res.status(200).send(articles))
     .catch(next);
 };
 
 module.exports.createArticle = (req, res, next) => {
-  const { keyword, title, text, date, source, link, image } = req.body;
+  const { keyword, title, description, publishedAt, source, url, urlToImage } = req.body;
 
-  Article.create({ keyword, title, text, date, source, link, image, owner: req.user._id })
+  Article.create({ keyword, title, description, publishedAt, source, url, urlToImage, owner: req.user._id })
     .then((article) => res.status(200).send({ article }))
     .catch(next);
 };

--- a/models/article.js
+++ b/models/article.js
@@ -10,11 +10,11 @@ const articleSchema = new mongoose.Schema({
     type: String,
     required: true,
   },
-  text: {
+  description: {
     type: String,
     required: true,
   },
-  date: {
+  publishedAt: {
     type: String,
     required: true,
   },
@@ -22,7 +22,7 @@ const articleSchema = new mongoose.Schema({
     type: String,
     required: true,
   },
-  link: {
+  url: {
     type: String,
     required: true,
     validate: {
@@ -31,7 +31,7 @@ const articleSchema = new mongoose.Schema({
       },
     },
   },
-  image: {
+  urlToImage: {
     type: String,
     required: true,
     validate: {

--- a/routes/articles.js
+++ b/routes/articles.js
@@ -18,11 +18,11 @@ router.post(
     body: Joi.object().keys({
       keyword: Joi.string().required(),
       title: Joi.string().required(),
-      text: Joi.string().required(),
-      date: Joi.string().required(),
+      description: Joi.string().required(),
+      publishedAt: Joi.string().required(),
       source: Joi.string().required(),
-      link: Joi.string().required().custom(validateUrl),
-      image: Joi.string().required().custom(validateUrl),
+      url: Joi.string().required().custom(validateUrl),
+      urlToImage: Joi.string().required().custom(validateUrl),
     }),
   }),
   createArticle


### PR DESCRIPTION
Changes:

1. Changed all keywords in article route, controller, model to match the keywords returned by the news API